### PR TITLE
[feat] 14 73 상단 네비게이션 바 작업

### DIFF
--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -2,14 +2,18 @@ import { cn } from '@/lib/shadcn/utils';
 
 import Nav from '@/components/layout/Nav';
 
-import type { ComponentProps } from 'react';
+import type { TagProps } from '@/types/components';
 
 type BottomNavProps = {
   children: React.ReactNode;
   className?: string;
-} & ComponentProps<'footer'>;
+};
 
-export default function BottomNav({ children, className, ...rest }: BottomNavProps) {
+export default function BottomNav({
+  children,
+  className,
+  ...rest
+}: TagProps<'footer', BottomNavProps>) {
   return (
     <Nav as="footer" className={cn('fixed bottom-0 left-0 z-100 w-full', className)} {...rest}>
       {children}

--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -2,14 +2,16 @@ import { cn } from '@/lib/shadcn/utils';
 
 import Nav from '@/components/layout/Nav';
 
-interface BottomNavProps {
+import type { ComponentProps } from 'react';
+
+type BottomNavProps = {
   children: React.ReactNode;
   className?: string;
-}
+} & ComponentProps<'footer'>;
 
-export default function BottomNav({ children, className }: BottomNavProps) {
+export default function BottomNav({ children, className, ...rest }: BottomNavProps) {
   return (
-    <Nav as="footer" className={cn('fixed bottom-0 left-0 z-100 w-full', className)}>
+    <Nav as="footer" className={cn('fixed bottom-0 left-0 z-100 w-full', className)} {...rest}>
       {children}
     </Nav>
   );

--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/lib/shadcn/utils';
+
+import Nav from '@/components/layout/Nav';
+
+interface BottomNavProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function BottomNav({ children, className }: BottomNavProps) {
+  return (
+    <Nav as="footer" className={cn('fixed bottom-0 left-0 z-100 w-full', className)}>
+      {children}
+    </Nav>
+  );
+}

--- a/src/components/common/BottomNav.tsx
+++ b/src/components/common/BottomNav.tsx
@@ -15,7 +15,11 @@ export default function BottomNav({
   ...rest
 }: TagProps<'footer', BottomNavProps>) {
   return (
-    <Nav as="footer" className={cn('fixed bottom-0 left-0 z-100 w-full', className)} {...rest}>
+    <Nav
+      as="footer"
+      className={cn('fixed bottom-0 left-0 z-100 w-full h-[64px]', className)}
+      {...rest}
+    >
       {children}
     </Nav>
   );

--- a/src/components/common/TopNav.tsx
+++ b/src/components/common/TopNav.tsx
@@ -2,14 +2,14 @@ import { cn } from '@/lib/shadcn/utils';
 
 import Nav from '@/components/layout/Nav';
 
-import type { ComponentProps } from 'react';
+import type { TagProps } from '@/types/components';
 
 type TopNavProps = {
   children: React.ReactNode;
   className?: string;
-} & ComponentProps<'header'>;
+};
 
-export default function TopNav({ children, className, ...rest }: TopNavProps) {
+export default function TopNav({ children, className, ...rest }: TagProps<'header', TopNavProps>) {
   return (
     <Nav as="header" className={cn('w-full', className)} {...rest}>
       {children}

--- a/src/components/common/TopNav.tsx
+++ b/src/components/common/TopNav.tsx
@@ -2,14 +2,16 @@ import { cn } from '@/lib/shadcn/utils';
 
 import Nav from '@/components/layout/Nav';
 
-interface TopNavProps {
+import type { ComponentProps } from 'react';
+
+type TopNavProps = {
   children: React.ReactNode;
   className?: string;
-}
+} & ComponentProps<'header'>;
 
-export default function TopNav({ children, className }: TopNavProps) {
+export default function TopNav({ children, className, ...rest }: TopNavProps) {
   return (
-    <Nav as="header" className={cn('w-full', className)}>
+    <Nav as="header" className={cn('w-full', className)} {...rest}>
       {children}
     </Nav>
   );

--- a/src/components/common/TopNav.tsx
+++ b/src/components/common/TopNav.tsx
@@ -11,7 +11,7 @@ type TopNavProps = {
 
 export default function TopNav({ children, className, ...rest }: TagProps<'header', TopNavProps>) {
   return (
-    <Nav as="header" className={cn('w-full', className)} {...rest}>
+    <Nav as="header" className={cn('w-full h-[56px]', className)} {...rest}>
       {children}
     </Nav>
   );

--- a/src/components/common/TopNav.tsx
+++ b/src/components/common/TopNav.tsx
@@ -1,0 +1,16 @@
+import { cn } from '@/lib/shadcn/utils';
+
+import Nav from '@/components/layout/Nav';
+
+interface TopNavProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function TopNav({ children, className }: TopNavProps) {
+  return (
+    <Nav as="header" className={cn('w-full', className)}>
+      {children}
+    </Nav>
+  );
+}

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -1,0 +1,47 @@
+import { Children } from 'react';
+
+import type { ComponentProps, ElementType } from 'react';
+
+import { cn } from '@/lib/shadcn/utils';
+
+export type PolymorphicProps<T extends ElementType, P> = {
+  as?: T;
+} & P &
+  ComponentProps<T>;
+
+const GRID_CLASSES = [
+  'grid-cols-1',
+  'grid-cols-2',
+  'grid-cols-3',
+  'grid-cols-4',
+  'grid-cols-5',
+  'grid-cols-6',
+  'grid-cols-7',
+  'grid-cols-8',
+  'grid-cols-9',
+  'grid-cols-10',
+  'grid-cols-11',
+  'grid-cols-12',
+];
+
+interface NavProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Nav<T extends ElementType = 'nav'>({
+  tag,
+  children,
+  className,
+}: PolymorphicProps<T, NavProps>) {
+  const Comp = tag ?? 'nav';
+
+  const childrenArray = Children.toArray(children);
+  const gridClass = GRID_CLASSES[childrenArray.length - 1] || 'grid-cols-1';
+
+  if (childrenArray.length > 12) {
+    throw new Error('TopNav 컴포넌트는 최대 12개의 자식 요소만 허용합니다.');
+  }
+
+  return <Comp className={cn(`grid ${gridClass} items-center`, className)}>{children}</Comp>;
+}

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -1,13 +1,9 @@
 import { Children } from 'react';
 
-import type { ComponentProps, ElementType } from 'react';
-
 import { cn } from '@/lib/shadcn/utils';
 
-export type PolymorphicProps<T extends ElementType, P> = {
-  as?: T;
-} & P &
-  ComponentProps<T>;
+import type { ElementType } from 'react';
+import type { PolymorphicProps } from '@/types/components';
 
 const GRID_CLASSES = [
   'grid-cols-1',

--- a/src/components/layout/Nav.tsx
+++ b/src/components/layout/Nav.tsx
@@ -33,6 +33,7 @@ export default function Nav<T extends ElementType = 'nav'>({
   tag,
   children,
   className,
+  ...rest
 }: PolymorphicProps<T, NavProps>) {
   const Comp = tag ?? 'nav';
 
@@ -43,5 +44,9 @@ export default function Nav<T extends ElementType = 'nav'>({
     throw new Error('TopNav 컴포넌트는 최대 12개의 자식 요소만 허용합니다.');
   }
 
-  return <Comp className={cn(`grid ${gridClass} items-center`, className)}>{children}</Comp>;
+  return (
+    <Comp className={cn(`grid ${gridClass} items-center`, className)} {...rest}>
+      {children}
+    </Comp>
+  );
 }

--- a/src/stories/common/BottomNav.stories.tsx
+++ b/src/stories/common/BottomNav.stories.tsx
@@ -1,0 +1,93 @@
+import BottomNav from '@/components/common/BottomNav';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta: Meta<typeof BottomNav> = {
+  title: 'Components/BottomNav',
+  component: BottomNav,
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component:
+          '하단 고정 네비게이션 컴포넌트입니다. children 개수에 따라 자동으로 grid-cols가 설정되며, footer 태그로 렌더링됩니다.',
+      },
+    },
+  },
+  argTypes: {
+    children: {
+      control: { type: 'object' },
+      description: 'BottomNav 내부에 표시될 자식 요소들',
+    },
+    className: {
+      control: { type: 'text' },
+      description: '추가 CSS 클래스',
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof BottomNav>;
+
+export const Default: Story = {
+  render: () => (
+    <BottomNav className="w-full h-[200px]">
+      <div className="flex flex-col items-center">
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M3 12l2-2m0 0l7-7 7 7M5 10v10a1 1 0 001 1h3m10-11l2 2m-2-2v10a1 1 0 01-1 1h-3m-6 0a1 1 0 001-1v-4a1 1 0 011-1h2a1 1 0 011 1v4a1 1 0 001 1m-6 0h6"
+          />
+        </svg>
+        <span>홈</span>
+      </div>
+      <div className="flex flex-col items-center text-sm text-gray-300">
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
+          />
+        </svg>
+        <span>검색</span>
+      </div>
+      <div className="flex flex-col items-center text-sm text-gray-300">
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+          />
+        </svg>
+        <span>추가</span>
+      </div>
+      <div className="flex flex-col items-center text-sm text-gray-300">
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"
+          />
+        </svg>
+        <span>채팅</span>
+      </div>
+      <div className="flex flex-col items-center text-sm text-gray-300">
+        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+          />
+        </svg>
+        <span>내정보</span>
+      </div>
+    </BottomNav>
+  ),
+};

--- a/src/stories/common/TopNav.stories.tsx
+++ b/src/stories/common/TopNav.stories.tsx
@@ -1,0 +1,96 @@
+import TopNav from '@/components/common/TopNav';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta: Meta<typeof TopNav> = {
+  title: 'Components/TopNav',
+  component: TopNav,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '상단 네비게이션 컴포넌트입니다. children 개수에 따라 자동으로 grid-cols가 설정되며, header 태그로 렌더링됩니다.',
+      },
+    },
+  },
+  argTypes: {
+    children: {
+      control: { type: 'object' },
+      description: 'TopNav 내부에 표시될 자식 요소들',
+    },
+    className: {
+      control: { type: 'text' },
+      description: '추가 CSS 클래스',
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof TopNav>;
+
+export const Default: Story = {
+  render: () => {
+    return (
+      <TopNav className="w-[400px] h-[200px] bg-white border border-gray-200">
+        <div className="w-full h-full header1 flex items-center justify-start pl-4">Headline</div>
+        <div className="w-full h-full flex items-center justify-end pr-2">
+          <SettingsButton />
+        </div>
+      </TopNav>
+    );
+  },
+};
+
+export const WithBackButton: Story = {
+  render: () => {
+    return (
+      <TopNav className="w-[400px] h-[200px] bg-white border border-gray-200">
+        <div className="w-full h-full flex items-center justify-start">
+          <BackButton />
+        </div>
+
+        <div className="w-full h-full header1 flex items-center justify-center">Headline</div>
+
+        <div className="w-full h-full flex items-center justify-end">
+          <SettingsButton />
+        </div>
+      </TopNav>
+    );
+  },
+};
+
+function BackButton() {
+  return (
+    <button className="flex items-center justify-center w-8 h-8 rounded-full hover:bg-gray-100 transition-colors">
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="m15 18-6-6 6-6" />
+      </svg>
+    </button>
+  );
+}
+
+function SettingsButton() {
+  return (
+    <button className="flex items-center justify-center w-8 h-8 rounded-full hover:bg-gray-100 transition-colors">
+      <svg
+        width="20"
+        height="20"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+      >
+        <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z" />
+        <circle cx="12" cy="12" r="3" />
+      </svg>
+    </button>
+  );
+}

--- a/src/stories/layout/Nav.stories.tsx
+++ b/src/stories/layout/Nav.stories.tsx
@@ -1,0 +1,88 @@
+import Nav from '@/components/layout/Nav';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta: Meta<typeof Nav> = {
+  title: 'design-system/Nav',
+  component: Nav,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'Polymorphic Nav 컴포넌트입니다. children 개수에 따라 자동으로 grid-cols가 설정되며, 다양한 HTML 요소로 렌더링할 수 있습니다.',
+      },
+    },
+  },
+  argTypes: {
+    tag: {
+      control: { type: 'select' },
+      options: ['nav', 'header', 'footer', 'div', 'section'],
+      description: '렌더링할 HTML 요소',
+    },
+    children: {
+      control: { type: 'object' },
+      description: 'Nav 내부에 표시될 자식 요소들',
+    },
+    className: {
+      control: { type: 'text' },
+      description: '추가 CSS 클래스',
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Nav>;
+
+// 2개
+export const TwoItems: Story = {
+  render: () => (
+    <Nav className="w-[500px] h-[200px] gap-x-2">
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">01</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">02</div>
+    </Nav>
+  ),
+};
+
+// 5개
+export const FiveItems: Story = {
+  render: () => (
+    <Nav className="w-[500px] h-[200px] gap-x-2">
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">01</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">02</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">03</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">04</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">05</div>
+    </Nav>
+  ),
+};
+
+// 12개
+export const TwelveItems: Story = {
+  render: () => (
+    <Nav className="w-[500px] h-[200px] gap-x-2">
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">02</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">03</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">04</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">05</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">06</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">07</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">08</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">09</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">10</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">11</div>
+      <div className="w-full h-full flex items-center justify-center bg-blue-200">12</div>
+    </Nav>
+  ),
+};
+
+// header
+export const Header: Story = {
+  render: () => (
+    <Nav as="header" className="w-[500px] h-[200px] border-2 border-red-500">
+      <div className="w-full h-full flex items-center justify-start">01</div>
+      <div className="w-full h-full flex items-center justify-end">02</div>
+    </Nav>
+  ),
+};

--- a/src/types/components.ts
+++ b/src/types/components.ts
@@ -1,0 +1,7 @@
+import type { ComponentProps, ElementType } from 'react';
+
+export type TagProps<Tag extends ElementType, Props> = ComponentProps<Tag> & Props;
+
+export type PolymorphicProps<Tag extends ElementType, Props> = {
+  as?: Tag;
+} & TagProps<Tag, Props>;


### PR DESCRIPTION
## ✅ 작업 내용
- [x] nav 컴포넌트 구현 (레이아웃)
- [x] 상단 네비게이션 바 구현
- [x] 하단 네비게이션 바 구현

- 컴포넌트 설명은 스토리북 실행 및 코드 보시면 알 수 있습니다.

## 📸 스크린샷  
<img width="1096" height="405" alt="스크린샷 2025-07-19 오전 12 37 27" src="https://github.com/user-attachments/assets/3cd71a38-eeb5-4663-86b7-9e8266f7ce16" />

<img width="1101" height="778" alt="스크린샷 2025-07-19 오전 12 37 13" src="https://github.com/user-attachments/assets/51643fcb-4fbd-4c6b-8be2-b5b91ec44a8c" />

<img width="1055" height="665" alt="스크린샷 2025-07-19 오전 12 37 42" src="https://github.com/user-attachments/assets/82856b68-ebe8-4f82-9a29-602d4a2aac65" />