### PR TITLE
[feat] 14 75 button 컴포넌트 구현

### DIFF
--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -22,7 +22,7 @@ export default function Button({
     'flex mx-auto bg-nt-primary text-nt-neutral-white hover:bg-nt-primary-400 cursor-pointer',
     'active:bg-nt-primary-600 disabled:opacity-100 disabled:bg-nt-neutral-200 disabled:text-nt-neutral-400',
     'focus-visible:border focus-visible:border-nt-primary focus-visible:ring-0 focus-visible:text-nt-primary focus-visible:bg-nt-neutral-white',
-    isActive && 'bg-nt-primary-100 text-nt-primary-600 border border-nt-primary-600'
+    isActive && !disabled && 'bg-nt-primary-100 text-nt-primary-600 border border-nt-primary-600'
   );
 
   const getVariantStyles = () => {

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,0 +1,59 @@
+import { Button as ShadcnButton } from '@/lib/shadcn/components/ui/button';
+import { cn } from '@/lib/shadcn/utils';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'default' | 'round' | 'square';
+  size?: 'md' | 'icon-sm' | 'icon-md';
+  isActive?: boolean;
+  disabled?: boolean;
+  children: React.ReactNode;
+}
+
+export default function Button({
+  variant = 'default',
+  size = 'md',
+  isActive = false,
+  disabled = false,
+  children,
+  className,
+  ...props
+}: ButtonProps) {
+  const baseStyles = cn(
+    'flex mx-auto bg-nt-primary text-nt-neutral-white hover:bg-nt-primary-400 cursor-pointer',
+    'active:bg-nt-primary-600 disabled:opacity-100 disabled:bg-nt-neutral-200 disabled:text-nt-neutral-400',
+    'focus-visible:border focus-visible:border-nt-primary focus-visible:ring-0 focus-visible:text-nt-primary focus-visible:bg-nt-neutral-white',
+    isActive && 'bg-nt-primary-100 text-nt-primary-600 border border-nt-primary-600'
+  );
+
+  const getVariantStyles = () => {
+    switch (variant) {
+      case 'default': // 기본 버튼 + 소셜 로그인(박스형)
+        return 'rounded-nt-radius w-[343px]';
+      case 'round': // 버튼-원형
+        return 'bg-nt-primary-100 rounded-full aspect-square';
+      case 'square': // 버튼-사각형
+        return 'bg-nt-primary-100 rounded-none aspect-square';
+    }
+  };
+
+  const getSizeStyles = () => {
+    switch (size) {
+      case 'md': // 기본 버튼
+        return 'h-[var(--nt-btn-h)]';
+      case 'icon-sm': // 소셜 로그인(원형)
+        return 'h-[50px]';
+      case 'icon-md': // 버튼-원형 & 버튼-사각형
+        return 'h-[60px]';
+    }
+  };
+
+  return (
+    <ShadcnButton
+      className={cn(baseStyles, getVariantStyles(), getSizeStyles(), className)}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </ShadcnButton>
+  );
+}

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -18,28 +18,32 @@ export default function Button({
   className,
   ...props
 }: ButtonProps) {
+  const iconBtn = variant === 'round' || variant === 'square';
+  const iconBtnStyle = 'bg-nt-primary-100 aspect-square';
+
   const baseStyles = cn(
     'flex bg-nt-primary text-nt-neutral-white hover:bg-nt-primary-400 cursor-pointer',
     'active:bg-nt-primary-600 disabled:opacity-100 disabled:bg-nt-neutral-200 disabled:text-nt-neutral-400',
     'focus-visible:border focus-visible:border-nt-primary focus-visible:ring-0 focus-visible:text-nt-primary focus-visible:bg-nt-neutral-white',
-    isActive && !disabled && 'bg-nt-primary-100 text-nt-primary-600 border border-nt-primary-600'
+    isActive && !disabled && 'bg-nt-primary-100 text-nt-primary-600 border border-nt-primary-600',
+    iconBtn && iconBtnStyle,
   );
 
   const getVariantStyles = () => {
     switch (variant) {
       case 'default': // 기본 버튼 + 소셜 로그인(박스형)
-        return 'rounded-nt-radius w-[343px]';
+        return 'rounded-nt-radius';
       case 'round': // 버튼-원형
-        return 'bg-nt-primary-100 rounded-full aspect-square';
+        return 'rounded-full';
       case 'square': // 버튼-사각형
-        return 'bg-nt-primary-100 rounded-none aspect-square';
+        return 'rounded-none';
     }
   };
 
   const getSizeStyles = () => {
     switch (size) {
       case 'md': // 기본 버튼
-        return 'h-[var(--nt-btn-h)]';
+        return 'h-[var(--nt-btn-h)] w-[343px]';
       case 'icon-sm': // 소셜 로그인(원형)
         return 'h-[50px]';
       case 'icon-md': // 버튼-원형 & 버튼-사각형

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -19,7 +19,7 @@ export default function Button({
   ...props
 }: ButtonProps) {
   const baseStyles = cn(
-    'flex mx-auto bg-nt-primary text-nt-neutral-white hover:bg-nt-primary-400 cursor-pointer',
+    'flex bg-nt-primary text-nt-neutral-white hover:bg-nt-primary-400 cursor-pointer',
     'active:bg-nt-primary-600 disabled:opacity-100 disabled:bg-nt-neutral-200 disabled:text-nt-neutral-400',
     'focus-visible:border focus-visible:border-nt-primary focus-visible:ring-0 focus-visible:text-nt-primary focus-visible:bg-nt-neutral-white',
     isActive && !disabled && 'bg-nt-primary-100 text-nt-primary-600 border border-nt-primary-600'


### PR DESCRIPTION
## ✅ 작업 내용
<!-- 어떤 작업을 했는지 요약해 주세요. 예: 기능 추가, 환경 설정, 리팩토링 등 -->
- [ ] 기본 버튼, 버튼-원형, 버튼-사각형, 소셜 로그인 버튼(박스형, 원형) 구현
- [ ] 스토리북 작성
## 📸 스크린샷  
<!-- UI 변경이 있다면 여기에 스크린샷을 첨부해주세요. -->
![기본버튼](https://github.com/user-attachments/assets/d9a9bb2f-23d8-4180-92dd-762246b18807)


## 🎸 기타  
<!-- 그 외 공유할 내용이 있다면 여기에 작성해주세요. -->
디자인 템플릿의 버튼에 존재하는 탭버튼과 토글버튼은 결이 달라서 다른 이슈로 빼서 작업하려 합니다.
나름 중복제거하고 깔끔하게 래핑한다고 작성해본건데, 수정할 사안 있으면 알려주세요.
구조 컨펌 받게되면 스토리북도 작성해놓겠습니다.