### PR TITLE
[feat] 14 81 PhotoCard 컴포넌트 구현

### DIFF
--- a/src/components/common/PhotoCard/Content.tsx
+++ b/src/components/common/PhotoCard/Content.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/shadcn/utils';
+
+import { CardContent } from '@/lib/shadcn/components/ui/card';
+
+import type { ComponentProps } from 'react';
+
+interface CardContentProps extends ComponentProps<'div'> {
+  className?: string;
+}
+
+export default function Content({ className, ...rest }: CardContentProps) {
+  return <CardContent className={cn('p-0', className)} {...rest} />;
+}

--- a/src/components/common/PhotoCard/Overlay.tsx
+++ b/src/components/common/PhotoCard/Overlay.tsx
@@ -1,0 +1,10 @@
+import { cn } from '@/lib/shadcn/utils';
+import type { ComponentProps } from 'react';
+
+interface OverlayProps extends ComponentProps<'div'> {
+  className?: string;
+}
+
+export default function Overlay({ className, ...rest }: OverlayProps) {
+  return <div className={cn('absolute inset-0 bg-white/20', className)} {...rest} />;
+}

--- a/src/components/common/PhotoCard/Photo.tsx
+++ b/src/components/common/PhotoCard/Photo.tsx
@@ -1,0 +1,27 @@
+import { cn } from '@/lib/shadcn/utils';
+import Image from 'next/image';
+
+import type { ComponentProps } from 'react';
+
+interface PhotoProps extends ComponentProps<'img'> {
+  src: string;
+  alt: string;
+  width: number;
+  height: number;
+  className?: string;
+}
+
+function Photo({ src, alt, width = 100, height = 100, className, ...rest }: PhotoProps) {
+  return (
+    <Image
+      src={src}
+      alt={alt}
+      width={width}
+      height={height}
+      className={cn('w-full h-full object-cover rounded-lg', className)}
+      {...rest}
+    />
+  );
+}
+
+export default Photo;

--- a/src/components/common/PhotoCard/Wrapper.tsx
+++ b/src/components/common/PhotoCard/Wrapper.tsx
@@ -1,0 +1,17 @@
+import { cn } from '@/lib/shadcn/utils';
+import { Card } from '@/lib/shadcn/components/ui/card';
+
+import type { ComponentProps } from 'react';
+
+interface WrapperProps extends ComponentProps<'div'> {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Wrapper({ children, className, ...rest }: WrapperProps) {
+  return (
+    <Card className={cn('relative p-0 gap-0', className)} {...rest}>
+      {children}
+    </Card>
+  );
+}

--- a/src/components/common/PhotoCard/index.ts
+++ b/src/components/common/PhotoCard/index.ts
@@ -1,0 +1,13 @@
+import Content from '@/components/common/PhotoCard/Content';
+import Overlay from '@/components/common/PhotoCard/Overlay';
+import Photo from '@/components/common/PhotoCard/Photo';
+import Wrapper from '@/components/common/PhotoCard/Wrapper';
+
+const PhotoCard = {
+  Wrapper,
+  Photo,
+  Overlay,
+  Content,
+} as const;
+
+export default PhotoCard;

--- a/src/lib/shadcn/components/ui/card.tsx
+++ b/src/lib/shadcn/components/ui/card.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+
+import { cn } from '@/lib/shadcn/utils';
+
+function Card({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        'bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        '@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn('leading-none font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn('col-start-2 row-span-2 row-start-1 self-start justify-self-end', className)}
+      {...props}
+    />
+  );
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<'div'>) {
+  return <div data-slot="card-content" className={cn('px-6', className)} {...props} />;
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn('flex items-center px-6 [.border-t]:pt-6', className)}
+      {...props}
+    />
+  );
+}
+
+export { Card, CardHeader, CardFooter, CardTitle, CardAction, CardDescription, CardContent };

--- a/src/stories/common/BottomNav.stories.tsx
+++ b/src/stories/common/BottomNav.stories.tsx
@@ -3,7 +3,7 @@ import BottomNav from '@/components/common/BottomNav';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta: Meta<typeof BottomNav> = {
-  title: 'Components/BottomNav',
+  title: 'design-system/BottomNav',
   component: BottomNav,
   parameters: {
     layout: 'fullscreen',

--- a/src/stories/common/PhotoCard.stories.tsx
+++ b/src/stories/common/PhotoCard.stories.tsx
@@ -1,0 +1,105 @@
+import PhotoCard from '@/components/common/PhotoCard';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta: Meta<typeof PhotoCard.Wrapper> = {
+  title: 'design-system/PhotoCard',
+  component: PhotoCard.Wrapper,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        props: {
+          Wrapper: {
+            description:
+              'PhotoCard를 감싸는 Wrapper컴포넌트입니다. classnames를 통해 추가 스타일링이 가능합니다.',
+          },
+          Photo: {
+            description:
+              'PhotoCard의 이미지 컴포넌트입니다. 이미지 크기를 조절하고, 클래스네임을 통해 추가 스타일링이 가능합니다.',
+          },
+          Overlay: {
+            description:
+              'PhotoCard의 오버레이 컴포넌트입니다. 반투명 오버레이를 추가하여 텍스트의 가독성을 높입니다.',
+          },
+          Content: {
+            description:
+              'PhotoCard의 컨텐츠 컴포넌트입니다. 텍스트 컨텐츠를 추가하고, 클래스네임을 통해 추가 스타일링이 가능합니다. (absolute 위치 조절 가능)',
+          },
+        },
+      },
+    },
+  },
+  render: () => (
+    <PhotoCard.Wrapper className="w-[300px] h-[200px] group cursor-pointer">
+      <PhotoCard.Photo
+        src="https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1000&q=80"
+        alt="오사카 풍경"
+        width={300}
+        height={200}
+      />
+      <PhotoCard.Content className="absolute bottom-4 left-4 z-10 text-white">
+        <h3 className="text-lg font-semibold mb-1">내가 본 오사카</h3>
+        <p className="text-sm opacity-90">밤에 간 해리포터 집</p>
+      </PhotoCard.Content>
+    </PhotoCard.Wrapper>
+  ),
+};
+
+export const WithOverlay: Story = {
+  render: () => (
+    <PhotoCard.Wrapper className="w-[300px] h-[200px] group cursor-pointer">
+      <PhotoCard.Photo
+        src="https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1000&q=80"
+        alt="오사카 풍경"
+        width={300}
+        height={200}
+      />
+      <PhotoCard.Overlay />
+      <PhotoCard.Content className="absolute bottom-4 left-4 z-10 text-white">
+        <h3 className="text-lg font-semibold mb-1">내가 본 오사카</h3>
+        <p className="text-sm opacity-90">밤에 간 해리포터 집</p>
+      </PhotoCard.Content>
+    </PhotoCard.Wrapper>
+  ),
+};
+
+export const AttractionCard: Story = {
+  render: () => (
+    <PhotoCard.Wrapper className="w-[300px] overflow-hidden group cursor-pointer">
+      <div className="relative">
+        <PhotoCard.Photo
+          src="https://images.unsplash.com/photo-1513635269975-59663e0ac1ad?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1000&q=80"
+          alt="오사카 풍경"
+          width={300}
+          height={180}
+          className="rounded-t-xl"
+        />
+      </div>
+
+      <PhotoCard.Content className="p-4">
+        <h3 className="text-lg font-semibold text-gray-900 mb-1">유니버설 스튜디오</h3>
+        <p className="text-sm text-gray-600 mb-2">오사카 • 어트랙션</p>
+
+        <div className="flex items-center gap-4 text-sm text-gray-500">
+          <div className="flex items-center gap-1">
+            <span className="text-yellow-500">★</span>
+            <span>5.0 (10)</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <span className="text-red-500">♥</span>
+            <span>200</span>
+          </div>
+        </div>
+      </PhotoCard.Content>
+    </PhotoCard.Wrapper>
+  ),
+};

--- a/src/stories/common/Progressbar.stories.tsx
+++ b/src/stories/common/Progressbar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 import Progressbar from '@/components/common/Progressbar';
 

--- a/src/stories/common/TopNav.stories.tsx
+++ b/src/stories/common/TopNav.stories.tsx
@@ -2,7 +2,7 @@ import TopNav from '@/components/common/TopNav';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 
 const meta: Meta<typeof TopNav> = {
-  title: 'Components/TopNav',
+  title: 'design-system/TopNav',
   component: TopNav,
   parameters: {
     layout: 'centered',


### PR DESCRIPTION
## ✅ 작업 내용

- [x] 사드시엔 Card 컴포넌트 생성 
- [x] PhotoCard 컴포넌트 구현
- [x] TopNav, BottomNav 스토리북 타이틀 수정
- [x] storybook 잘못된 import 코드 수정

PhotoCard 컴포넌트의 경우 스토리북 실행 및 코드를 보시면 쉽게 이해하실 수 있을 것 같습니다.    


## 📸 스크린샷  
<!-- UI 변경이 있다면 여기에 스크린샷을 첨부해주세요. -->
<img width="439" height="279" alt="스크린샷 2025-07-19 오후 6 47 48" src="https://github.com/user-attachments/assets/46302835-f311-4872-98c1-7cc54cc16d59" />
<img width="430" height="289" alt="스크린샷 2025-07-19 오후 6 48 02" src="https://github.com/user-attachments/assets/f4eb4d2e-0538-449a-a4dd-73f658b438dd" />
<img width="408" height="387" alt="스크린샷 2025-07-19 오후 6 48 13" src="https://github.com/user-attachments/assets/dd9dc29c-850e-432c-a432-61e1765888ff" />


## 🎸 기타  
<!-- 그 외 공유할 내용이 있다면 여기에 작성해주세요. -->