### PR TITLE
[Feat] 14 77 badge 컴포넌트 구현

### DIFF
--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/shadcn/utils';
+
+type BadgeProps = {
+  children: React.ReactNode;
+  className?: string;
+};
+
+export default function Badge({ children, className }: BadgeProps) {
+  const badgeClass =
+    'flex items-center justify-center w-[53px] h-[28px] rounded-full bg-nt-neutral-white border border-nt-primary font-medium text-xs';
+
+  return <div className={cn(badgeClass, className)}>{children}</div>;
+}

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -1,13 +1,16 @@
 import { cn } from '@/lib/shadcn/utils';
 
-type BadgeProps = {
+type BadgeProps = React.HTMLAttributes<HTMLDivElement> & {
   children: React.ReactNode;
-  className?: string;
 };
 
-export default function Badge({ children, className }: BadgeProps) {
+export default function Badge({ children, className, ...props }: BadgeProps) {
   const badgeClass =
     'flex items-center justify-center w-[53px] h-[28px] rounded-full bg-nt-neutral-white border border-nt-primary font-medium text-xs';
 
-  return <div className={cn(badgeClass, className)}>{children}</div>;
+  return (
+    <div className={cn(badgeClass, className)} {...props}>
+      {children}
+    </div>
+  );
 }

--- a/src/stories/common/Badge.stories.tsx
+++ b/src/stories/common/Badge.stories.tsx
@@ -1,0 +1,53 @@
+import Badge from '@/components/common/Badge';
+
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+const meta: Meta<typeof Badge> = {
+  title: 'design-system/Badge',
+  component: Badge,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '뱃지 컴포넌트입니다. 추가 className을 통해 사이즈 및 색상을 변경할 수 있습니다.',
+      },
+    },
+  },
+  argTypes: {
+    children: {
+      control: { type: 'object' },
+      description: 'Badge 내부에 표시될 자식 요소들',
+    },
+    className: {
+      control: { type: 'text' },
+      description: '추가 CSS 클래스',
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Badge>Lv.4</Badge>
+      <Badge className='w-[100px]'>Lv.4</Badge>
+    </div>
+  ),
+};
+
+export const ColorVariant: Story = {
+  render: () => (
+    <div className="flex flex-col gap-4">
+      <Badge>Lv.4</Badge>
+      <Badge className="text-nt-neutral-white bg-nt-secondary-500 border-none">Lv.4</Badge>
+      <Badge className="text-nt-neutral-white bg-nt-primary border-none">Lv.4</Badge>
+      <Badge className="text-nt-neutral-white nt-gradient-primary-to-secondary border-none">
+        Lv.5
+      </Badge>
+    </div>
+  ),
+};


### PR DESCRIPTION
## ✅ 작업 내용
<!-- 어떤 작업을 했는지 요약해 주세요. 예: 기능 추가, 환경 설정, 리팩토링 등 -->
- [x] Badge 컴포넌트 구현
- [x] Badge 스토리북 작성

## 📸 스크린샷  
<!-- UI 변경이 있다면 여기에 스크린샷을 첨부해주세요. -->
<img width="1264" height="520" alt="image" src="https://github.com/user-attachments/assets/2a9e8af5-643a-4498-82f5-ea944a5b2cfb" />


## 🎸 기타  
<!-- 그 외 공유할 내용이 있다면 여기에 작성해주세요. -->
뱃지는 크기 배리에이션이 다양할 것 같지 않아서 디자인 시스템에 나온대로 기본 사이즈를 w-[53px] h-[28px]로 설정해두었습니다.

또한, border와 bg에 색상을 넣어주지 않으면 올화이트 형태가 되어 뱃지의 형상이 안나와서 기본 border는 `nt-primary`, bg는 `nt-neutral-white`로 초기화했습니다.
<img width="240" height="206" alt="image" src="https://github.com/user-attachments/assets/98c4c8e6-223f-4183-b842-53350853618c" />

-> 뱃지의 형상이 안보임
