### PR TITLE
Hotfix/좋아요 페이지 연동 오류 수정

### DIFF
--- a/src/components/pages/DetailPage/DetailPageContent.tsx
+++ b/src/components/pages/DetailPage/DetailPageContent.tsx
@@ -124,8 +124,8 @@ export default function DetailPageContent({ id }: DetailPageContentProps) {
           <div className="header3 text-nt-neutral-900">상세정보</div>
           {detailData.data.spotDetails.length === 0 && '없음'}
           {detailData.data.spotDetails.map(detail => (
-            <div key={detail} className="flex flex-col gap-1.5 px-4 py-2.5">
-              <span className="body2 text-nt-neutral-400">{detail}</span>
+            <div key={detail.type} className="flex flex-col gap-1.5 px-4 py-2.5">
+              <span className="body2 text-nt-neutral-400">{detail.label}</span>
             </div>
           ))}
         </div>

--- a/src/components/pages/DetailPage/detail/entities.tsx
+++ b/src/components/pages/DetailPage/detail/entities.tsx
@@ -23,7 +23,10 @@ export interface DetailSpot {
   mainImage: string | null;
   isLiked: boolean;
   spotImages: string[];
-  spotDetails: string[];
+  spotDetails: {
+    type: string,
+    label: string
+  }[];
 }
 
 export type DetailSpotResponse = GenericAPIResponse<DetailSpot>;

--- a/src/components/pages/DetailPage/like/entities.tsx
+++ b/src/components/pages/DetailPage/like/entities.tsx
@@ -57,6 +57,8 @@ export const useLikeMutation = (touristSpotId: string) => {
           };
         },
       );
+
+      queryClient.invalidateQueries({ queryKey: ['user', 'myPage'] });
     },
   });
 };

--- a/src/components/pages/LoadMorePage/PopularPage/LoadMorePageContent.tsx
+++ b/src/components/pages/LoadMorePage/PopularPage/LoadMorePageContent.tsx
@@ -3,13 +3,9 @@
 import { useInfiniteMoreNightPopular } from '@/components/pages/LoadMorePage/entities';
 import Header from '@/components/pages/LoadMorePage/ui/Header';
 import TripCard from '@/components/pages/LoadMorePage/ui/TripCard';
-import { useSearchParams } from 'next/navigation';
 import { useEffect, useRef } from 'react';
 
 export default function LoadMorePageContent() {
-  const searchParams = useSearchParams();
-  const type = searchParams.get('type') ?? '';
-
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteMoreNightPopular();
 
   const observerRef = useRef<HTMLDivElement | null>(null);
@@ -35,7 +31,7 @@ export default function LoadMorePageContent() {
 
   return (
     <div>
-      <Header title={type} />
+      <Header />
       <div className="flex flex-wrap justify-between p-3">
         {allContent.map((content, idx) => (
           <div key={content.id ?? idx} className="w-[162px] h-[218px]">

--- a/src/components/pages/LoadMorePage/ui/Header.tsx
+++ b/src/components/pages/LoadMorePage/ui/Header.tsx
@@ -2,10 +2,16 @@ import Button from '@/components/common/Button';
 import TopNav from '@/components/common/TopNav';
 import Link from 'next/link';
 import Back from '@/icons/back.svg';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 
-export default function Header({ title }: { title: string }) {
-  const headerTitle = title || '나잇트립 인기 여행지';
+export default function Header({ title }: { title?: string }) {
+  const pathname = usePathname();
+  const isCategory = pathname.includes('/category');
+  const headerTitle = title
+    ? isCategory
+      ? `회원님을 위한 [${title}] 추천`
+      : `나잇트립이 엄선한 [${title}] 추천`
+    : '밤에 떠나기 좋은 추천 여행지';
 
   const router = useRouter();
 

--- a/src/components/pages/MainPage/category/index.tsx
+++ b/src/components/pages/MainPage/category/index.tsx
@@ -13,7 +13,7 @@ export default function NightRecommendCategory() {
     <>
       <div className="px-4 h-[42px] flex items-center justify-between">
         <h3 className="font-semibold text-nt-neutral-black leading-6">
-          {recommendedSpots.data.category}
+          회원님을 위한 [{recommendedSpots.data.category}] 추천
         </h3>
         {recommendedSpots.data.isMore && (
           <Link

--- a/src/components/pages/MainPage/popular/index.tsx
+++ b/src/components/pages/MainPage/popular/index.tsx
@@ -11,7 +11,7 @@ export default function NightPopularSpot() {
   return (
     <>
       <div className="px-4 h-[42px] flex items-center justify-between">
-        <h3 className="font-semibold text-nt-neutral-black leading-6">인기 많은 여행지</h3>
+        <h3 className="font-semibold text-nt-neutral-black leading-6">밤에 떠나기 좋은 추천 여행지</h3>
         {nightPopularSpots.data.isMore && (
           <Link
             className="text-sm text-[#5B58C2] active:bg-nt-primary-50 p-1 rounded-nt-radius"

--- a/src/components/pages/RecommendPage/random-category/index.tsx
+++ b/src/components/pages/RecommendPage/random-category/index.tsx
@@ -11,7 +11,7 @@ export default function NightRandomRecommendCategory() {
     <>
       <div className="px-4 h-[42px] flex items-center justify-between">
         <h3 className="font-semibold text-nt-neutral-black leading-6">
-          {randomCategoryData.category}
+          나잇트립이 엄선한 [{randomCategoryData.category}] 추천
         </h3>
         <Link
           className="text-sm text-[#5B58C2] active:bg-nt-primary-50 p-1 rounded-nt-radius"


### PR DESCRIPTION
## ✅ 작업 내용
<!-- 어떤 작업을 했는지 요약해 주세요. 예: 기능 추가, 환경 설정, 리팩토링 등 -->
- [ ] 좋아요 페이지 연동 오류 수정
- [ ] 추천 페이지 타이틀 수정 
- [ ] 더보기 페이지 타이틀 수정 (url에 따른 타이틀 형식 분기 처리)
  - 나잇트립이 엄선한 ~~, 회원님을 위한 ~~, 밤에 떠나기 좋은 여행지 

## 📸 스크린샷  
<!-- UI 변경이 있다면 여기에 스크린샷을 첨부해주세요. -->
### 좋아요 페이지 연동 오류 수정
![mypage-likes](https://github.com/user-attachments/assets/7f52b1c4-830a-4e19-8b06-860239f5eed5)

### 추천 페이지 타이틀 수정
<메인>
<img width="754" height="1270" alt="image" src="https://github.com/user-attachments/assets/a2dbd19f-aa68-40a8-84c7-1d6b9dfeaff8" />

<추천>
<img width="768" height="1274" alt="image" src="https://github.com/user-attachments/assets/6c873a1d-2ed9-4f2e-94fb-ab62166236ff" />

<더보기>
<img width="770" height="1280" alt="image" src="https://github.com/user-attachments/assets/0dc98191-1231-41b7-bb9e-fe99cb7b7512" />

## 🎸 기타  
<!-- 그 외 공유할 내용이 있다면 여기에 작성해주세요. -->