### PR TITLE
hofix: 하단 푸터 디자인 수정 및 헤더 스타일 수정

### DIFF
--- a/src/components/common/footer.tsx
+++ b/src/components/common/footer.tsx
@@ -6,9 +6,6 @@ import MyIcon from '@/icons/my.svg';
 import ActiveMyIcon from '@/icons/active_my.svg';
 import HomeIcon from '@/icons/home.svg';
 import ActiveHomeIcon from '@/icons/active_home.svg';
-import PlanIcon from '@/icons/plan.svg';
-import ActivePlanIcon from '@/icons/active_plan.svg';
-
 import BottomNav from '@/components/common/BottomNav';
 
 import Link from 'next/link';
@@ -17,12 +14,9 @@ export default function Footer() {
   const pathname = usePathname();
 
   return (
-    <BottomNav className="w-[375px] bg-[#FAF9FF] rounded-t-xl">
+    <BottomNav className="w-[375px] bg-[#FAF9FF] rounded-t-xl z-[100]">
       <Link href="/" className="flex flex-col items-center w-full">
         {pathname === '/' ? <ActiveHomeIcon /> : <HomeIcon />}
-      </Link>
-      <Link href="/schedule" className="flex flex-col items-center">
-        {pathname === '/plan' ? <ActivePlanIcon /> : <PlanIcon />}
       </Link>
       <Link href="/my" className="flex flex-col items-center">
         {pathname === '/my' ? <ActiveMyIcon /> : <MyIcon />}

--- a/src/components/pages/DetailPage/DetailPageContent.tsx
+++ b/src/components/pages/DetailPage/DetailPageContent.tsx
@@ -3,8 +3,6 @@
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 
-import TopNav from '@/components/common/TopNav';
-
 import BackIcon from '@/icons/back.svg';
 import AddressIcon from '@/icons/address.svg';
 import PhoneIcon from '@/icons/phone.svg';
@@ -44,16 +42,18 @@ export default function DetailPageContent({ id }: DetailPageContentProps) {
 
   return (
     <>
-      <TopNav>
+      <header className="w-full h-[42px] flex items-center justify-between">
         <button
           onClick={handleBackClick}
           className="w-[42px] h-[42px] bg-nt-white active:bg-nt-primary-50 p-2 rounded-nt-radius"
         >
           <BackIcon />
         </button>
-        <p className="mx-auto header2">{detailData.data.spotName}</p>
-        <div />
-      </TopNav>
+        <p className="max-w-[300px] header2 text-center overflow-hidden text-ellipsis whitespace-nowrap">
+          {detailData.data.spotName}
+        </p>
+        <div className="w-[42px] h-[42px]" />
+      </header>
       <div className="py-5 px-4">
         <div className="relative">
           {detailData.data.spotImages.length > 0 ? (

--- a/src/components/pages/DetailPage/DetailPageContent.tsx
+++ b/src/components/pages/DetailPage/DetailPageContent.tsx
@@ -124,8 +124,8 @@ export default function DetailPageContent({ id }: DetailPageContentProps) {
           <div className="header3 text-nt-neutral-900">상세정보</div>
           {detailData.data.spotDetails.length === 0 && '없음'}
           {detailData.data.spotDetails.map(detail => (
-            <div key={detail.type} className="flex flex-col gap-1.5 px-4 py-2.5">
-              <span className="body2 text-nt-neutral-400">{detail.label}</span>
+            <div key={detail.type}>
+              - <span className="body2 text-nt-neutral-400">{detail.label}</span>
             </div>
           ))}
         </div>

--- a/src/components/pages/MainPage/ui/header.tsx
+++ b/src/components/pages/MainPage/ui/header.tsx
@@ -1,18 +1,12 @@
 import TopNav from '@/components/common/TopNav';
 
 import LogoIcon from '@/icons/logo.svg';
-import AddTravelIcon from '@/icons/add-travel.svg';
 
 export default function Header() {
   return (
     <TopNav>
       <div className="w-full h-full header1 flex items-center justify-start pl-4">
         <LogoIcon />
-      </div>
-      <div className="w-full h-full flex items-center justify-end pr-2">
-        <button className="bg-nt-white active:bg-nt-primary-50 p-2 rounded-nt-radius">
-          <AddTravelIcon />
-        </button>
       </div>
     </TopNav>
   );


### PR DESCRIPTION
## ✅ 작업 내용
<!-- 어떤 작업을 했는지 요약해 주세요. 예: 기능 추가, 환경 설정, 리팩토링 등 -->
- [x] 상단 디테일 페이지 스타일 수정
- [x] 하단 푸터 여행 일정 라우팅 버튼 제거


## 📸 스크린샷  
<!-- UI 변경이 있다면 여기에 스크린샷을 첨부해주세요. -->


## 🎸 기타  
<!-- 그 외 공유할 내용이 있다면 여기에 작성해주세요. -->