### PR TITLE
[Hotfix] 모달 위치 조정

### DIFF
--- a/src/components/common/Modal/Content.tsx
+++ b/src/components/common/Modal/Content.tsx
@@ -7,9 +7,12 @@ interface ModalContentProps extends React.ComponentProps<typeof DialogContent> {
 
 export default function ModalContent({ title, children, ...rest }: ModalContentProps) {
   return (
-    <DialogContent {...rest}>
-      <Nav title={title} />
-      {children}
-    </DialogContent>
+    <>
+      <div className="fixed inset-0 bg-black/60 z-[9998]" />
+      <DialogContent {...rest}>
+        <Nav title={title} />
+        {children}
+      </DialogContent>
+    </>
   );
 }

--- a/src/components/pages/LoginPage/ui/header.tsx
+++ b/src/components/pages/LoginPage/ui/header.tsx
@@ -1,16 +1,29 @@
+'use client';
+
 import Button from '@/components/common/Button';
 import TopNav from '@/components/common/TopNav';
 
 import Back from '@/icons/back.svg';
-import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 export default function Header() {
+  const router = useRouter();
+
+  const handleBackClick = () => {
+    if (window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/');
+    }
+  };
+
   return (
     <TopNav>
-      <Button className="w-[42px] h-[42px] bg-transparent shadow-none text-black">
-        <Link href="/">
-          <Back />
-        </Link>
+      <Button
+        className="w-[42px] h-[42px] bg-transparent shadow-none text-black"
+        onClick={handleBackClick}
+      >
+        <Back />
       </Button>
     </TopNav>
   );

--- a/src/provider/global.tsx
+++ b/src/provider/global.tsx
@@ -9,7 +9,7 @@ function ModalProvider({ children }: { children: React.ReactNode }) {
   const { isOpen, modal, content } = useModal();
 
   return (
-    <Modal.Wrapper open={isOpen} onOpenChange={modal.loginError}>
+    <Modal.Wrapper open={isOpen} onOpenChange={modal.loginError} modal={false}>
       {children}
       {content}
     </Modal.Wrapper>


### PR DESCRIPTION
## ✅ 작업 내용
<!-- 어떤 작업을 했는지 요약해 주세요. 예: 기능 추가, 환경 설정, 리팩토링 등 -->
- [x] 모달 중앙정렬 안되던 문제 임시 해결

## 📸 스크린샷  
<!-- UI 변경이 있다면 여기에 스크린샷을 첨부해주세요. -->
<img width="886" height="1354" alt="image" src="https://github.com/user-attachments/assets/ed8e297e-1a52-4a0f-a7a4-ad6dc67dfeb1" />


## 🎸 기타  
<!-- 그 외 공유할 내용이 있다면 여기에 작성해주세요. -->
shadcn의 dialog overlay 기본동작이 스크롤바 부분까지 덮어서 모달이 띄워지도록하는데, 이부분때문에 중앙정렬이 저희 서비스 화면과 안맞는 문제가 생겼습니다.
(서비스 화면-> 스크롤바까지 포함한 width에서 중앙정렬, 모달-> 스크롤바 미포함한 전체 width에서 중앙정렬)

shadcn 내부 동작을 건드는게 많이 힘들어보여서 dialog의 기본 overlay 동작을 삭제하고 자체 overlay를 사용해서 임시로 해결했습니다. 임시인 이유는 실제로 useModal에 의해 불려지는게 아닌, Modal.Trigger가 들어가게되면 Trigger부분까지 overlay가 적용되기 때문입니다. 일단 현재 구현 사항에 대해서 동작이 안되는 부분은 없고, 이 부분은 추후 시간 더 쓰면서 해결해 보겠습니다.