### PR TITLE
[Feat] OptionButtons 컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-label": "^2.1.7",
+        "@radix-ui/react-radio-group": "^1.3.8",
         "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tabs": "^1.1.12",
         "@tanstack/react-query": "^5.82.0",
@@ -3496,6 +3498,29 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.7.tgz",
+      "integrity": "sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-portal": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
@@ -3551,6 +3576,99 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-radio-group/-/react-radio-group-1.3.8.tgz",
+      "integrity": "sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-radio-group/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+      "integrity": "sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3721,6 +3839,39 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-label": "^2.1.7",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.12",
     "@tanstack/react-query": "^5.82.0",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -231,6 +231,10 @@
     @apply font-semibold leading-[24px];
   }
 
+  .header5 {
+    @apply !font-semibold leading-[22px];
+  }
+
   .body1 {
     @apply text-base font-normal leading-6;
   }

--- a/src/components/common/OptionButtons.tsx
+++ b/src/components/common/OptionButtons.tsx
@@ -1,0 +1,36 @@
+import { RadioGroup, RadioGroupItem } from '@/lib/shadcn/components/ui/radio-group';
+import { Label } from '@/lib/shadcn/components/ui/label';
+import { cn } from '@/lib/shadcn/utils';
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+interface OptionButtonsProps {
+  options: Option[];
+  value?: string;
+  onChange?: (value: string) => void;
+  className?: string;
+}
+
+export default function OptionButtons({ options, value, onChange, className }: OptionButtonsProps) {
+  return (
+    <RadioGroup value={value} onValueChange={onChange} className={cn('flex flex-wrap gap-5', className)}>
+      {options.map(option => (
+        <div key={option.value} className="flex items-center">
+          <RadioGroupItem value={option.value} id={option.value} className="hidden" />
+          <Label
+            htmlFor={option.value}
+            className={cn(
+              'px-4 py-2 h-[42px] rounded-[10px] header5 cursor-pointer transition-colors hover:bg-nt-neutral-300',
+              value === option.value ? 'bg-nt-neutral-dark-gray text-nt-neutral-white' : 'bg-nt-neutral-250 text-nt-neutral-400',
+            )}
+          >
+            {option.label}
+          </Label>
+        </div>
+      ))}
+    </RadioGroup>
+  );
+}

--- a/src/components/common/OptionButtons.tsx
+++ b/src/components/common/OptionButtons.tsx
@@ -19,7 +19,7 @@ export default function OptionButtons({ options, value, onChange, className }: O
     <RadioGroup value={value} onValueChange={onChange} className={cn('flex flex-wrap gap-5', className)}>
       {options.map(option => (
         <div key={option.value} className="flex items-center">
-          <RadioGroupItem value={option.value} id={option.value} className="hidden" />
+          <RadioGroupItem value={option.value} id={option.value} className="sr-only" />
           <Label
             htmlFor={option.value}
             className={cn(

--- a/src/lib/shadcn/components/ui/label.tsx
+++ b/src/lib/shadcn/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+
+import { cn } from "@/lib/shadcn/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/src/lib/shadcn/components/ui/radio-group.tsx
+++ b/src/lib/shadcn/components/ui/radio-group.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { CircleIcon } from "lucide-react"
+
+import { cn } from "@/lib/shadcn/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "border-input text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:bg-input/30 aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="fill-primary absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/src/stories/common/OptionButtons.stories.tsx
+++ b/src/stories/common/OptionButtons.stories.tsx
@@ -1,0 +1,96 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import OptionButtons from '@/components/common/OptionButtons';
+import { useState } from 'react';
+
+const meta: Meta<typeof OptionButtons> = {
+  title: 'design-system/OptionButtons',
+  component: OptionButtons,
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: '버튼 스타일로 커스텀된 라디오 그룹 컴포넌트입니다. 옵션을 선택할 수 있습니다.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof OptionButtons>;
+
+export const Default: Story = {
+  render: () => {
+    const [selected, setSelected] = useState('two');
+    return (
+      <OptionButtons
+        options={[
+          { value: 'one', label: '당일여행' },
+          { value: 'two', label: '하룻밤 힐링 (1박 2일)' },
+          { value: 'three', label: '이틀 밤 (2박 3일)' },
+          { value: 'four', label: '별빛 세 밤 (3박 4일)' },
+          { value: 'five', label: '달빛 네 밤 (4박 5일)' },
+          { value: 'six', label: '한 주의 밤 (6박 7일)' },
+        ]}
+        value={selected}
+        onChange={setSelected}
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '여행 기간 옵션 버튼을 선택할 수 있습니다.',
+      },
+    },
+  },
+};
+
+export const FewOptions: Story = {
+  render: () => {
+    const [selected, setSelected] = useState('one');
+    return (
+      <OptionButtons
+        options={[
+          { value: 'one', label: '옵션1' },
+          { value: 'two', label: '옵션2' },
+          { value: 'three', label: '옵션3' },
+        ]}
+        value={selected}
+        onChange={setSelected}
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '옵션이 3개인 버튼 그룹 예시입니다.',
+      },
+    },
+  },
+};
+
+export const CustomStyle: Story = {
+  render: () => {
+    const [selected, setSelected] = useState('three');
+    return (
+      <OptionButtons
+        options={[
+          { value: 'one', label: 'A' },
+          { value: 'two', label: 'B' },
+          { value: 'three', label: 'C' },
+        ]}
+        value={selected}
+        onChange={setSelected}
+        className="flex-nowrap gap-3"
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: '커스텀 스타일(className) 적용 예시입니다.',
+      },
+    },
+  },
+};

--- a/src/stories/common/OptionButtons.stories.tsx
+++ b/src/stories/common/OptionButtons.stories.tsx
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof OptionButtons>;
 
 export const Default: Story = {
   render: () => {
-    const [selected, setSelected] = useState('two');
+    const [selected, setSelected] = useState('one');
     return (
       <OptionButtons
         options={[


### PR DESCRIPTION
## ✅ 작업 내용
- shadcn의 RadioGroup을 매핑한 OptionButtons 컴포넌트 구현
- globals.css에 header5 클래스 추가


## 📸 스크린샷  
<img width="1398" height="692" alt="image" src="https://github.com/user-attachments/assets/0e929b11-9ae4-4abe-8422-e77c3a10e81a" />


## 🎸 기타  
<!-- 그 외 공유할 내용이 있다면 여기에 작성해주세요. -->